### PR TITLE
[REF] ci: adding proper php version to tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: PHP Composer
 
 on:
   push:
-    branches: ["master"]
+    branches: ["*"]
   pull_request:
     branches: ["master"]
 
@@ -10,9 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        php-version: ["8.4"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR provides a small fix to the php workflow action to allow running the tests properly on github.